### PR TITLE
 Add ability to have a CORS Preflight hanlder.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chiisai"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 description = "A micro framework for micro services!"
 license = "MIT/Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@ impl<'c> Service for &'c Chiisai
                     }
                     let url_in = ftry!(base.clone().join(&url));
                     let test = ftry!(base.clone().join(&req.path()));
-                    let mut url_in= ftry_opt!(url_in.path_segments());
-                    let mut test = ftry_opt!(test.path_segments());
+                    let url_in= ftry_opt!(url_in.path_segments());
+                    let test = ftry_opt!(test.path_segments());
 
                     let size1 = url_in.clone().count();
                     let size2 = test.clone().count();
@@ -158,6 +158,19 @@ macro_rules! router {
             $(
                 let boxed: Box<Route<Method = hyper::Method>> = Box::new($handler);
                 map.insert((boxed.method(), $route.to_string()), boxed);
+            )*
+            map
+        }
+    };
+    ($( ($route: expr, $handler: expr))*, ($cors: expr)) => {
+        {
+            use std::collections::HashMap;
+            let mut map = HashMap::new();
+            $(
+                let boxed: Box<Route<Method = hyper::Method>> = Box::new($handler);
+                map.insert((boxed.method(), $route.to_string()), boxed);
+                let cors: Box<Route<Method = hyper::Method>> = Box::new($cors);
+                map.insert((cors.method(), $route.to_string()), cors);
             )*
             map
         }


### PR DESCRIPTION
The macro for `router!()` has been changed to take a only a Route
name like (Cors) at the end. This will implicitly add it for all routes.

However, you need to still specify it's method as Options in order for
it to work the way you want. This is not middleware and won't work that
way. You'll need to write the handler to send back the Cors request you
want to send back.